### PR TITLE
Corrigida a métrica ModifiersPerNounPhrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Scarton, C., Gasperin, C., & Aluisio, S. (2010). Revisiting the Readability Asse
 Dependencies
 ============
 
-For Coh-Metrix-Port to run properly, you must first install these Python libraries:
+For Coh-Metrix-Port to run properly, you must first install the Python dependencies (optionally in a [virtualenv](https://virtualenv.pypa.io/en/stable/)):
+
+	$ pip install -r requirements.txt
 
 License
 =======


### PR DESCRIPTION
FIX: métrica ModifiersPerNounPhrase estava usando a etiqueta errada
(`ADJ` do nlpnet ao invés de `A` do LX-Parser), contando todos os NPs
(somente os NPs que não são contidos em outros devem contar) e só
procurava por modificadores como filhos diretos de NPs (devem ser
contados todos os filhos, mesmo os indiretos).